### PR TITLE
Fix wrong MouseEvent mapping in termion and crossterm backends

### DIFF
--- a/src/backend/crossterm/mapping.rs
+++ b/src/backend/crossterm/mapping.rs
@@ -87,7 +87,7 @@ impl From<event::MouseEvent> for MouseEvent {
     fn from(event: event::MouseEvent) -> Self {
         match event {
             event::MouseEvent::Down(btn, x, y, modifiers) => {
-                MouseEvent::Up(btn.into(), x, y, modifiers.into())
+                MouseEvent::Down(btn.into(), x, y, modifiers.into())
             }
             event::MouseEvent::Up(btn, x, y, modifiers) => {
                 MouseEvent::Up(btn.into(), x, y, modifiers.into())

--- a/src/backend/termion/mapping.rs
+++ b/src/backend/termion/mapping.rs
@@ -30,7 +30,7 @@ impl From<event::MouseEvent> for MouseEvent {
                 } else if btn == event::MouseButton::WheelUp {
                     MouseEvent::ScrollUp(x, y, KeyModifiers::empty())
                 } else {
-                    MouseEvent::Up(btn.into(), x, y, KeyModifiers::empty())
+                    MouseEvent::Down(btn.into(), x, y, KeyModifiers::empty())
                 }
             }
             event::MouseEvent::Release(x, y) => {


### PR DESCRIPTION
With the termion and crossterm backends, MouseEvent::Up is fired instead of MouseEvent::Down when the mouse is pressed.
This PR fixes this issue